### PR TITLE
Avoid setting nil to dictionary by checking whether the object is nil or not

### DIFF
--- a/FCIPAddressGeocoder/FCIPAddressGeocoder.m
+++ b/FCIPAddressGeocoder/FCIPAddressGeocoder.m
@@ -294,13 +294,13 @@ static NSString *customDefaultServiceURL = nil;
                     _locationCountryCode = dataCountryCode;
 
                     NSMutableDictionary *info = [[NSMutableDictionary alloc] init];
-                    [info setObject:data forKey:@"raw"]; //service response
-                    [info setObject:dataIP forKey:@"ip"];
-                    [info setObject:dataLatitude forKey:@"latitude"];
-                    [info setObject:dataLongitude forKey:@"longitude"];
-                    [info setObject:dataCity forKey:@"city"];
-                    [info setObject:dataCountry forKey:@"country"];
-                    [info setObject:dataCountryCode forKey:@"countryCode"];
+                    if( data != nil )               [info setObject:data forKey:@"raw"]; //service response
+                    if( dataIP != nil )             [info setObject:dataIP forKey:@"ip"];
+                    if( dataLatitude != nil )       [info setObject:dataLatitude forKey:@"latitude"];
+                    if( dataLongitude != nil )      [info setObject:dataLongitude forKey:@"longitude"];
+                    if( dataCity != nil )           [info setObject:dataCity forKey:@"city"];
+                    if( dataCountry != nil )        [info setObject:dataCountry forKey:@"country"];
+                    if( dataCountryCode != nil )    [info setObject:dataCountryCode forKey:@"countryCode"];
                     _locationInfo = [NSDictionary dictionaryWithDictionary:info];
                 }
                 else {


### PR DESCRIPTION
I encountered a crash after geocoding. The reason is `dataCity` is nil when it's set to `self.locationInfo`. The stacktrace (from Crashlytics) is below.

```
Fatal Exception: NSInvalidArgumentException
*** setObjectForKey: object cannot be nil (key: city)
```

```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x1be27b3d __exceptionPreprocess
1  libobjc.A.dylib                0x1b0af067 objc_exception_throw
2  CoreFoundation                 0x1bd3c88d -[__NSDictionaryM setObject:forKey:]
3  FCIPAddressGeocoder            0xee4c0d (Missing)
4  CFNetwork                      0x1c412cc5 __67+[NSURLConnection sendAsynchronousRequest:queue:completionHandler:]_block_invoke_2
5  Foundation                     0x1c74dac1 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__
6  Foundation                     0x1c6a3aaf -[NSBlockOperation main]
7  Foundation                     0x1c695fa7 -[__NSOperationInternal _start:]
8  Foundation                     0x1c74fcf9 __NSOQSchedule_f
9  libdispatch.dylib              0x1b50259d _dispatch_queue_serial_drain
10 libdispatch.dylib              0x1b4f8b71 _dispatch_queue_invoke
11 libdispatch.dylib              0x1b5041b5 _dispatch_root_queue_drain
12 libdispatch.dylib              0x1b50400f _dispatch_worker_thread3
13 libsystem_pthread.dylib        0x1b6aa87d _pthread_wqthread
14 libsystem_pthread.dylib        0x1b6aa45c start_wqthread
```

So I fixed the code to avoid setting nil to `NSMutableDictionary` by checking whether the object is nil or not.